### PR TITLE
Add manual Docker build workflow

### DIFF
--- a/.github/workflows/manual-ghcr-build.yml
+++ b/.github/workflows/manual-ghcr-build.yml
@@ -1,0 +1,45 @@
+name: Manual Docker Build
+
+on:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Set repository and image name to lowercase
+        run: |
+          echo "IMAGE_NAME=${IMAGE_NAME,,}" >> $GITHUB_ENV
+          echo "FULL_IMAGE_NAME=${REGISTRY}/${IMAGE_NAME,,}" >> $GITHUB_ENV
+        env:
+          IMAGE_NAME: '${{ github.repository }}'
+          REGISTRY: ${{ env.REGISTRY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ env.FULL_IMAGE_NAME }}:latest
+          build-args: |
+            BUILD_HASH=${{ github.sha }}
+


### PR DESCRIPTION
## Summary
- enable manual GitHub Actions workflow to build and push container image

## Testing
- `npm run test:frontend` *(fails: vitest not found)*
- `npm ci` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68464b455c9c832f9aa08f2354e4dacc