### PR TITLE
Add manual Docker build workflow

### DIFF
--- a/.github/workflows/manual-ghcr-build.yml
+++ b/.github/workflows/manual-ghcr-build.yml
@@ -1,0 +1,45 @@
+name: Manual Docker Build
+
+on:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Set repository and image name to lowercase
+        run: |
+          echo "IMAGE_NAME=${IMAGE_NAME,,}" >> $GITHUB_ENV
+          echo "FULL_IMAGE_NAME=${REGISTRY}/${IMAGE_NAME,,}" >> $GITHUB_ENV
+        env:
+          IMAGE_NAME: '${{ github.repository }}'
+          REGISTRY: ${{ env.REGISTRY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_PAT || github.token }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ env.FULL_IMAGE_NAME }}:latest
+          build-args: |
+            BUILD_HASH=${{ github.sha }}
+

--- a/README.md
+++ b/README.md
@@ -208,6 +208,10 @@ In the last part of the command, replace `open-webui` with your container name i
 
 Check our Updating Guide available in our [Open WebUI Documentation](https://docs.openwebui.com/getting-started/updating).
 
+### Building and Publishing Your Own Docker Image
+
+If you want to create a custom Docker image, the repository includes a `Manual Docker Build` workflow. To push images to GitHub Container Registry (GHCR), add a secret named `GHCR_PAT` with a Personal Access Token that has the `packages:write` scope. Then trigger the workflow from the **Actions** tab.
+
 ### Using the Dev Branch 🌙
 
 > [!WARNING]


### PR DESCRIPTION
## Summary
- enable manual GitHub Actions workflow to build and push container image
- support GHCR_PAT for authentication
- document how to trigger the workflow

## Testing
- `npm run test:frontend` *(fails: vitest not found)*
- `npm ci` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68464b455c9c832f9aa08f2354e4dacc